### PR TITLE
Add support for event flag useCapture

### DIFF
--- a/events.js
+++ b/events.js
@@ -8,47 +8,51 @@ var $       = require("./index"),
 
 var html = document.documentElement
 
-var addEventListener = html.addEventListener ? function(node, event, handle){
-    node.addEventListener(event, handle, false)
+var addEventListener = html.addEventListener ? function(node, event, handle, useCapture){
+    node.addEventListener(event, handle, useCapture || false)
     return handle
 } : function(node, event, handle){
     node.attachEvent('on' + event, handle)
     return handle
 }
 
-var removeEventListener = html.removeEventListener ? function(node, event, handle){
-    node.removeEventListener(event, handle, false)
+var removeEventListener = html.removeEventListener ? function(node, event, handle, useCapture){
+    node.removeEventListener(event, handle, useCapture || false)
 } : function(node, event, handle){
     node.detachEvent("on" + event, handle)
 }
 
 $.implement({
 
-    on: function(event, handle){
+    on: function(event, handle, useCapture){
 
         return this.forEach(function(node){
             var self = $(node)
 
-            Emitter.prototype.on.call(self, event, handle)
+            var internalEvent = event + (useCapture ? ":capture" : "")
+
+            Emitter.prototype.on.call(self, internalEvent, handle)
 
             var domListeners = self._domListeners || (self._domListeners = {})
-            if (!domListeners[event]) domListeners[event] = addEventListener(node, event, function(e){
-                self.emit(event, e || window.event, Emitter.EMIT_SYNC)
-            })
+            if (!domListeners[internalEvent]) domListeners[internalEvent] = addEventListener(node, event, function(e){
+                Emitter.prototype.emit.call(self, internalEvent, e || window.event, Emitter.EMIT_SYNC)
+            }, useCapture)
         })
     },
 
-    off: function(event, handle){
+    off: function(event, handle, useCapture){
 
         return this.forEach(function(node){
 
             var self = $(node)
 
+            var internalEvent = event + (useCapture ? ":capture" : "")
+
             var domListeners = self._domListeners, domEvent, listeners = self._listeners, events
 
-            if (domListeners && (domEvent = domListeners[event]) && listeners && (events = listeners[event])){
+            if (domListeners && (domEvent = domListeners[internalEvent]) && listeners && (events = listeners[internalEvent])){
 
-                Emitter.prototype.off.call(self, event, handle)
+                Emitter.prototype.off.call(self, internalEvent, handle)
 
                 var empty = true, k, l
                 for (k in events){
@@ -57,8 +61,8 @@ $.implement({
                 }
 
                 if (empty){
-                    removeEventListener(node, event, domEvent)
-                    delete domListeners[event]
+                    removeEventListener(node, event, domEvent, useCapture)
+                    delete domListeners[internalEvent]
 
                     for (l in domListeners){
                         empty = false

--- a/test/events.html
+++ b/test/events.html
@@ -13,6 +13,7 @@
 <div id="mocha"></div>
 
 <div id="container">click me</div>
+<div id="capture-container">click me (capture)</div>
 
 <form id="form">
     <input id="input" type="text">

--- a/test/events.js
+++ b/test/events.js
@@ -7,12 +7,13 @@ var expect = require('expect.js')
 
 describe('events.js', function(){
 
-    var body, container, form, input, submit
+    var body, container, captureContainer, form, input, submit
 
     before(function(){
         body = $(document.documentElement)
 
         container = $(document.getElementById('container'))
+        captureContainer = $(document.getElementById('capture-container'))
 
         form   = $(document.getElementById('form'))
         input  = $(document.getElementById('input'))
@@ -50,6 +51,28 @@ describe('events.js', function(){
             container.on('click', function(event){
                 container[0].innerHTML = (this == container) ? 'equal' : 'wop'
             })
+        })
+    })
+
+    describe("on('click', handler, useCapture)", function(){
+        it('should attach an event listener', function(){
+            var windowHandlerCalled = false;
+
+            captureContainer.on('click', function(event){
+                captureContainer[0].innerHTML = windowHandlerCalled ? 'element:afterwindow' : 'element'
+            })
+
+            // This handler should be called first, because it uses the capture phase.
+            // This means that the handler above will be called after, and the innerHTML
+            // will finally be 'element', as set in the above handler.
+            var handler = function(event){
+                captureContainer[0].innerHTML = 'window'
+                windowHandlerCalled = true;
+            };
+            $(window).on('click', handler, true)
+
+            // This should not remove the handler, since the useCapture flag must match
+            $(window).off('click', handler)
         })
     })
 

--- a/test/eventsCasper.js
+++ b/test/eventsCasper.js
@@ -27,6 +27,13 @@ function testContainer(expect, msg){
         }, expect, msg)
     }
 }
+function testCaptureContainer(expect, msg){
+    return function(){
+        casper.test.assertEvalEquals(function(){
+            return document.querySelector('#capture-container').innerHTML
+        }, expect, msg)
+    }
+}
 
 // click
 
@@ -37,6 +44,15 @@ casper.then(function(){
 
 casper.then(
     testContainer("equal", "this should be the same as the element the event is added to")
+)
+
+casper.then(function(){
+    this.echo('click an elements (capture)', 'INFO')
+    this.click('#capture-container')
+})
+
+casper.then(
+    testCaptureContainer("element:afterwindow", "the handler on the element should be triggered after the one on window (when using capture)")
 )
 
 // keydown


### PR DESCRIPTION
This passes the flag on to the addEventListener call.
Added tests for this, that run in Casper.

Used like you would expect:

``` javascript
$(window).on('click', handler, true); // uses capture
```
