### PR TITLE
Use window instead of global

### DIFF
--- a/base.js
+++ b/base.js
@@ -18,7 +18,7 @@ var index = 0,
     key = "uid:" + counter
 
 var uniqueID = function(n){
-    if (n === global) return "global"
+    if (n === window) return "window"
     if (n === document) return "document"
     if (n === document.documentElement) return "html"
     return n[key] || (n[key] = (index++).toString(36))
@@ -44,7 +44,7 @@ var $ = prime({constructor: function $(n, context){
             return self.search(n)
         }
 
-        if (n.nodeType || n === global){
+        if (n.nodeType || n === window){
 
             self[self.length++] = n
 


### PR DESCRIPTION
We expect global to be window, so we can just use window directly.
Using global caused problems when running tests with jsdom, since
we then create a new window object, but we can't replace global
with that, we can only assign global.window to the new window.
