### PR TITLE
zen: Use empty string as fallback when setting an attribute

### DIFF
--- a/zen.js
+++ b/zen.js
@@ -24,7 +24,7 @@ module.exports = function(expression, doc){
             if (part.classList) node.className = part.classList.join(" ")
 
             if (part.attributes) forEach(part.attributes, function(attribute){
-                node.setAttribute(attribute.name, attribute.value)
+                node.setAttribute(attribute.name, attribute.value || "")
             })
 
             if (part.pseudos) forEach(part.pseudos, function(pseudo){


### PR DESCRIPTION
If the attribute value is parsed as null or undefined, it will be
stringified inside the setAttribute method, and the attribute
value will be set to 'null' or 'undefined'. Falling back on an
empty string will most likely cause a more expected behavior.
