### PR TITLE
Support for useCapture in delegation

### DIFF
--- a/delegation.js
+++ b/delegation.js
@@ -9,7 +9,7 @@ var $ = require("./events")
 
 $.implement({
 
-    delegate: function(event, selector, handle){
+    delegate: function(event, selector, handle, useCapture){
 
         return this.forEach(function(node){
 
@@ -34,13 +34,13 @@ $.implement({
 
             map.set(handle, action)
 
-            self.on(event, action)
+            self.on(event, action, useCapture)
 
         })
 
     },
 
-    undelegate: function(event, selector, handle){
+    undelegate: function(event, selector, handle, useCapture){
 
         return this.forEach(function(node){
 
@@ -51,7 +51,7 @@ $.implement({
             var action = map.get(handle)
 
             if (action){
-                self.off(event, action)
+                self.off(event, action, useCapture)
                 map.remove(action)
 
                 // if there are no more handles in a given selector, delete it

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -703,7 +703,7 @@ instance.
 ### syntax
 
 ```js
-myElement.delegate(type, selector, fn)
+myElement.delegate(type, selector, fn[, useCapture])
 ```
 
 ### parameters
@@ -712,6 +712,7 @@ myElement.delegate(type, selector, fn)
 2. selector - (*string*) A CSS Selector the element the event is fired on should
 match (see [matches](#method-matches))
 3. fn - (*function*) The function to execute.
+4. useCapture - (*boolean*, optional) Whether to use initiate capture
 
 ### sample
 
@@ -740,7 +741,7 @@ Removes a delegation event listener from an element. Opposite operation of
 ### syntax
 
 ```js
-myElement.undelegate(type, selector, fn)
+myElement.undelegate(type, selector, fn[, useCapture])
 ```
 
 ### parameters
@@ -749,6 +750,7 @@ myElement.undelegate(type, selector, fn)
 2. selector - (*string*) A CSS Selector the element the event is fired on should
 match (see [matches](#method-matches)).
 3. fn   - (*function*) The function to remove.
+4. useCapture - (*boolean*, optional) If the event was registered as a capturing listener or not
 
 ### sample
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elements",
   "description": "prime dom library",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT (http://mootools.net/license.txt)",
   "main": "./index.js",
   "keywords": [


### PR DESCRIPTION
For events that don't bubble, like `focus` or `blur`, it is very useful being able to pass useCapture to the emitter from the `delegate`.
